### PR TITLE
More pretty messages and content container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,33 @@
 # DarkCloud
 ![users](https://img.shields.io/chrome-web-store/d/mjicdmidmifkppilbbcanmnljpffmfmh.svg?label=users)
+![rating](https://img.shields.io/chrome-web-store/rating-count/mjicdmidmifkppilbbcanmnljpffmfmh?label=rating)
+![stars](https://img.shields.io/chrome-web-store/rating/mjicdmidmifkppilbbcanmnljpffmfmh?label=stars)
 
-A darker theme for SoundCloud.
-
-Chrome:
-https://chrome.google.com/webstore/detail/darkcloud/mjicdmidmifkppilbbcanmnljpffmfmh
-
-Firefox:
-https://addons.mozilla.org/en-US/firefox/addon/darkcloud-original/
+## A darker theme for SoundCloud.
 
 This extension will help your SoundCloud look way cooler than it normally is.
-Who doesn't like the darker taste of websites?
+Who doesn't like the darker taste of websites? Either because it's cooler or you just want to go easy on your eyes, this extension is for you.
 
-Either because it's cooler or you just want to go easy on your eyes, this extension is for you.
+![screenshot](images/screencroped.png)
 
-![screenshot](https://github.com/iamdiogo/DarkCloud/blob/master/images/screencroped.png)
+Feel absolutely free to contribute to it, I will be more than happy. Also, if you found a bug, please report it back to me.
 
-Feel absolutely free to contribute to it, I will be more than happy.
+## Download
 
-Also, if you found a bug, please report it back to me.
+You can download DarkCloud extension from official stores for 
+- *Google Chrome* in [Chrome Web Store](https://chrome.google.com/webstore/detail/darkcloud/mjicdmidmifkppilbbcanmnljpffmfmh)
+- *Mozilla Firefox* on [Firefox Addons](https://addons.mozilla.org/en-US/firefox/addon/darkcloud-original/) 
+
 
 ## Changelog:
+
+17.11.2019: v1.0.9
+- Major fixes for messages interface
+- Content container now fits the entire page
+
+10.11.2019: v1.0.82
+- Fixed free upload limit background
+- Fixed stream playlist expand button.
 
 11.10.2019: v1.0.8.1
 - Fixed interaction area on old album layout (thanks to Franckevicius)

--- a/css_dark.css
+++ b/css_dark.css
@@ -1,6 +1,6 @@
 /* This is where all the magic happens! */
 
-body{background-color:#0b0c0c !important;color: #fff !important; background-image: unset !important}
+body{color: #fff !important;background: #0b0c0c url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABNgAAABkCAYAAABU8Y1hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAALeSURBVHhe7dgxEYAADMDAggg4/AuFBQXN+r/EQ47rft4BAAAAAFbOvwAAAADAgsEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAACBwQYAAAAAgcEGAAAAAIHBBgAAAABrMx991AIN/iqaoQAAAABJRU5ErkJggg==) repeat-y 50% 0 !important;} /* changed background color and image, which is a *container image* */
 .playControls__inner, .playControls__bg{background-color:#121414 !important;}
 .playControl{filter:invert(100%) !important;}
 .skipControl__previous{filter:invert(100%) !important;}
@@ -165,6 +165,7 @@ textarea, select, input{background: #000 !important}
 .conversation__actions {background-color: #0f1010 !important; padding-right: 0; padding-bottom: 32px; height: unset !important; box-sizing: content-box !important;} /* Fix current user header in messages */
 .conversationActions {margin-right: 26px;} /* Fix buttons position */
 .conversationMessage__body {color: #f0f0f0 !important;} /* Fix message color */
+.conversation__messages {padding-top: 128px !important;} /* Increase messages padding to make a space between user title and messages history */
 .composeMessage .textfield__input,
 .composeMessage .composeMessage__bottomWrapper {border: none;} /* Fix text input box */
 .composeMessage .composeMessage__bottomWrapper {background-color: transparent;} /* Fix bottom wrapper background color */

--- a/css_dark.css
+++ b/css_dark.css
@@ -158,3 +158,13 @@ textarea, select, input{background: #000 !important}
 .callout__bubble::before{background-color: black !important;} /* Fixes informational pop-ups shown to new users (2/2) */
 .quotaMeterWrapper{background-color: unset !important;} /* Fixes free upload limit background */
 .compactTrackList__moreLink:focus, .compactTrackList__moreLink:hover{background-color: black !important; color: white !important} /* Fixes stream playlist expand btn */
+.l-messages-left.sc-border-box > div {border: none !important;} /* Fix border */
+.l-messages-left .inbox__item::before {display: none;} /* Fix last messages border */
+.l-messages-left.sc-border-box .inbox__listWrapper .inbox__list .g-scrollable-inner {padding-right: 0 !important; margin-right: 30px; width: unset !important; height: unset !important;} /* Fix messages scrollable */
+.l-messages-left.sc-border-box .inbox__listWrapper .inbox__list .lazyLoadingList__list {margin-bottom: 0 !important;} /* Fix bottom margin for messages */
+.conversation__actions {background-color: #0f1010 !important; padding-right: 0; padding-bottom: 32px; height: unset !important; box-sizing: content-box !important;} /* Fix current user header in messages */
+.conversationActions {margin-right: 26px;} /* Fix buttons position */
+.conversationMessage__body {color: #f0f0f0 !important;} /* Fix message color */
+.composeMessage .textfield__input,
+.composeMessage .composeMessage__bottomWrapper {border: none;} /* Fix text input box */
+.composeMessage .composeMessage__bottomWrapper {background-color: transparent;} /* Fix bottom wrapper background color */

--- a/css_dark.css
+++ b/css_dark.css
@@ -168,3 +168,6 @@ textarea, select, input{background: #000 !important}
 .composeMessage .textfield__input,
 .composeMessage .composeMessage__bottomWrapper {border: none;} /* Fix text input box */
 .composeMessage .composeMessage__bottomWrapper {background-color: transparent;} /* Fix bottom wrapper background color */
+::-webkit-scrollbar {width: 2px;} /* Webkit only scrollbar */
+::-webkit-scrollbar-track {background-color: #000;}
+::-webkit-scrollbar-thumb {border-radius: 4px; background-color: #F85402;}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "DarkCloud",
   "description": "SoundCloud Dark Theme",
-  "version": "1.0.8.2",
+  "version": "1.0.9",
   "permissions": ["activeTab"],
   "icons": {"128": "darklogo.png" },
   "background": {


### PR DESCRIPTION
## Messages fixes
Major messages ui fixes like deleting borders, recalculated margins and etc. In short, there are images to see the differences. By the point, now content container *fits* the entire height (actually no, it's an image attached to `body` background)

Also a thin orange *webkit-only* scrollbar was added, it looks pretty enough for the *dark and orange* style (it is not on images)

**How it was**

![How it was before](https://user-images.githubusercontent.com/35663012/69006160-55c6c880-093c-11ea-8dac-4c9f3f197e31.png)

**How it is now**

![How it is now](https://user-images.githubusercontent.com/35663012/69006161-55c6c880-093c-11ea-94ba-7b0989c643f5.png)
