### PR TITLE
fixing some white backgrounds and borders

### DIFF
--- a/css_dark.css
+++ b/css_dark.css
@@ -76,7 +76,7 @@ textarea, select, input{background: #000 !important}
 .g-tabs-link:hover, .g-tabs-link:focus{border-color: #fff !important}
 .dropbar__content{background-color: #0c0c0c !important}
 .infoStats__value{color: #fff !important}
-.truncatedAudioInfo.m-overflow.m-collapsed .truncatedAudioInfo__wrapper::after{background: linear-gradient(rgba(255,255,255,0),rgba(255,255,255,.1)90%,#000) !important}
+.truncatedAudioInfo.m-overflow.m-collapsed .truncatedAudioInfo__wrapper::after{background: linear-gradient(rgba(255,255,255,0),rgba(255,255,255,.1) 90%,#000) !important}
 .sc-button-selected.sc-button-medium.sc-button-like:before{filter: invert(0%) !important;}
 .sc-button-medium.sc-button-like:before{filter: invert(100%) !important;}
 .sc-button-selected.sc-button-medium.sc-button-repost:before{filter: invert(0%) !important;}
@@ -166,3 +166,6 @@ textarea, select, input{background: #000 !important}
 .featuredProfiles__list .sc-status-icon{filter: invert(100) !important;} /* Fix featured profiles text 2/2 */
 .sc-button-delete::before{filter: invert(100%) !important;} /* Fix delete playlist button */
 .sc-button-small.sc-button-lightfg:before{filter: unset !important;} /* Fix playlist preview song buttons */
+.sc-classic .keyboardShortcuts__shortcutsGroup>dl>dt>kbd>kbd {background: #222222 !important; } /* Removing the white background in the "Keyboard Shortcuts" page*/
+.image__whiteOutline .image__full {border: 2px solid #161719 !important;} /* Removing the white borders from avatars in the stream page*/
+.sc-classic .artistShortcutTile__badge {border: 2px solid #161719 !important;} /* Removing the white borders from the orange icon near the "Latest from people you know" header*/


### PR DESCRIPTION
I don't know if it is personal taste, removed some annoying white borders from some icons and fixed the lack of contrast difference between the keys and text on the "Keyboard Shortcuts" page.

**Here are some changes:**
**_Before_**
![Screenshot 2022-04-17 212326](https://user-images.githubusercontent.com/79096051/163737735-fc7c4b3a-a90c-45fb-b765-6dcdb00d88c0.png)

**_After_**
![Screenshot 2022-04-17 212200](https://user-images.githubusercontent.com/79096051/163737752-3251fb93-c7d0-45f0-aaad-26429dfa3338.png)


**_Before_**
![Screenshot 2022-04-17 212256](https://user-images.githubusercontent.com/79096051/163737763-abe08a4d-969e-46ab-8144-e241a41922bd.png)

**_After_**
![Screenshot 2022-04-17 212233](https://user-images.githubusercontent.com/79096051/163737781-3be58561-7026-44cb-9ef0-7aa7ebc9e2f5.png)


**_Before_**
![Screenshot 2022-04-17 212309](https://user-images.githubusercontent.com/79096051/163737790-30e6f803-ce1f-4f58-b0b3-37eed4c76a1e.png)

**_After_**
![Screenshot 2022-04-17 212218](https://user-images.githubusercontent.com/79096051/163737796-96fec563-190e-4aa0-b459-49a3cf1a30d1.png)

