### PR TITLE
Fix who to follow module header

### DIFF
--- a/css_dark.css
+++ b/css_dark.css
@@ -171,3 +171,6 @@ textarea, select, input{background: #000 !important}
 .sc-classic .keyboardShortcuts__shortcutsGroup>dl>dt>kbd>kbd {background: #222222 !important; } /* Removing the white background in the "Keyboard Shortcuts" page*/
 .image__whiteOutline .image__full {border: 2px solid #161719 !important;} /* Removing the white borders from avatars in the stream page*/
 .sc-classic .artistShortcutTile__badge {border: 2px solid #161719 !important;} /* Removing the white borders from the orange icon near the "Latest from people you know" header*/
+.whoToFollowModule .sidebarHeader__title {white-space: nowrap; display: grid; grid-template-columns: auto 1fr;} /* Forbid who to follow module title to wrap. */
+.whoToFollowModule .sidebarHeader__actualTitle {overflow: hidden; text-overflow: ellipsis;} /* Hide who to follow module title overflow. */
+.whoToFollowModule .sidebarHeader__more {white-space: nowrap} /* Forbid who to follow module reload text to wrap. */


### PR DESCRIPTION
Existing issue with the original CSS, but this bothers me a lot tbh

Before:
<img width="334" alt="Capture d’écran 2023-01-16 à 14 06 54" src="https://user-images.githubusercontent.com/15245704/212685690-e2be482d-f970-40af-9dad-3e3865be5d06.png">

After:
<img width="333" alt="Capture d’écran 2023-01-16 à 14 07 27" src="https://user-images.githubusercontent.com/15245704/212685716-69d6f8fc-2c52-42ef-894d-e4bdfb9c01ea.png">
