### PR TITLE
Fix border top for comment module

### DIFF
--- a/css_dark.css
+++ b/css_dark.css
@@ -70,6 +70,7 @@ textarea, select, input{background: #000 !important}
 .queueItemView:hover, .queueItemView.m-active{background: #151619 !important}
 .header{background: #111111 !important}
 .sc-border-light-top{border-top: 1px solid #44494f !important}
+.commentBadgeList__item:first-child {border-top: 0 !important;} /* Do not display a border for first comment on profile page. */
 .profileHeaderBackground{background: #111111 !important}
 .l-fixed-top-one-column>.l-top{background: #161719 !important} /* Fixes profile's likes page header */
 .sc-button-medium.sc-button-message:before{filter: invert(100%) !important;}


### PR DESCRIPTION
We're incorrectly displaying a border on top of the first item in the comments module of a profile page (because of the `!important` set on line 72).

Before:
<img width="332" alt="Capture d’écran 2023-01-16 à 14 30 12" src="https://user-images.githubusercontent.com/15245704/212690176-f5f84e52-2c17-47bd-915c-923824b56ac5.png">

After:
<img width="330" alt="Capture d’écran 2023-01-16 à 14 30 42" src="https://user-images.githubusercontent.com/15245704/212690207-ed380859-f768-458b-8cb6-acfac97578c0.png">
